### PR TITLE
SYWA-9: opzetten rabbitmq docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/docker-compose.override.yml
+.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,16 @@
 version: '2.0'
 services:
   word-dump-service:
-    image: sywa/word-dump-service:latest
+    image: scrabbleyourword/word-dump-service:latest
     ports:
-    - 9000:8080
+      - 9000:8080
   word-processing-service:
-    image: sywa/word-processing-service:latest
+    image: scrabbleyourword/word-processing-service:latest
     ports:
-    - 9001:8080
+      - 9001:8080
+  rabbit:
+    image: rabbitmq
+  rabbit-manager:
+    image: rabbitmq:3-management
+    ports:
+      - 9002:15672


### PR DESCRIPTION
# SYWA-9: Configuratie RabbitMQ:

## Wat is er gedaan:
### 🐰 RabbitMQ opzetten
In deze PR is de rabbitMQ dependency toegevoegd om ervoor te zorgen dat we de verwerkte woorden op een bus kunnen zetten.

### ℹ Minor changes:

- Docker-compose geupdatet met een correcte indentatie voor de gebruikte poorten.
- Updaten van de repository images naar het gebruik van dockerhub images.
- Toevoegen van een .gitignore die de `docker-compose.override.yml` en `idea` folder zal ignoren in de git commits.

###  ❌ Wat is er niet gedaan:
Er is geen configuratie toegevoegd voor de opzet van de RabbitMQ, dit zal in een andere story gedaan worden.

