### PR TITLE
SYWA-1: definitie elasticsearch met kibana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/docker-compose.override.yml
+.idea

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,27 @@ services:
     image: sywa/word-processing-service:latest
     ports:
     - 9001:8080
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    container_name: elasticsearch1
+    environment:
+      - node.name=elasticsearch1
+      - cluster.name=docker-cluster
+      - cluster.initial_master_nodes=elasticsearch1
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms256M -Xmx256M"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 9200:9200
+      - 9300:9300
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.6.2
+    container_name: kibana
+    environment:
+      SERVER_NAME: localhost
+      ELASTICSEARCH_URL: http://elasticsearch1:9200/
+    ports:
+      - 5601:5601


### PR DESCRIPTION
# SYWA-1: Configuratie Elasticsearch en Kibana:

## Wat is er gedaan:
###  🔧 Beperkte Elk stack opzetten
De laatste versie (7.6.2) van elasticsearch en Kibana draaien in deze PR via `docker-compose`.

###  🧪 Hoe testen?
Bij het uitvoeren van `docker-compose up -d` kan je surfen naar `localhost:9200` en krijg je een resultaat terug te zien van elasticSearch.

Hierna kan je surfen naar `localhost:5601` en krijg je de interface te zien van Kibana.

### ℹ Minor changes:

- Toevoegen van een .gitignore die de `docker-compose.override.yml` en `idea` folder zal ignoren in de git commits.

##  ❓ Wat moet er nog gedaan worden na deze PR:
De gebruikte poorten dienen correct gezet te worden om de volgorde te volgen van de andere services (een poort in de 9000 range).
