### PR TITLE
SYWA-2: Configuring elasticSearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,3 +14,52 @@ services:
     image: rabbitmq:3-management
     ports:
       - 9002:15672
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    container_name: elasticsearch1
+    environment:
+      - node.name=elasticsearch1
+      - cluster.name=docker-cluster
+      - cluster.initial_master_nodes=elasticsearch1
+      - discovery.seed_hosts=elasticsearch2
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms256M -Xmx256M"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 9200:9200
+      - 9300:9300
+    volumes:
+      - data01:/usr/share/elasticsearch/data
+  elasticsearch2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    container_name: elasticsearch2
+    environment:
+      - node.name=elasticsearch2
+      - cluster.name=docker-cluster
+      - cluster.initial_master_nodes=elasticsearch1
+      - discovery.seed_hosts=elasticsearch1
+      - bootstrap.memory_lock=true
+      - node.data=true
+      - "ES_JAVA_OPTS=-Xms256M -Xmx256M"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - data02:/usr/share/elasticsearch/data
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.6.2
+    container_name: kibana
+    environment:
+      SERVER_NAME: localhost
+      ELASTICSEARCH_URL: http://elasticsearch1:9200/
+    ports:
+      - 5601:5601
+volumes:
+  data01:
+    driver: local
+  data02:
+    driver: local


### PR DESCRIPTION
# 🕵🏻‍♂️ SYWA-2: Configuring elasticSearch

## What has been done:
### 🔊🔊 Data volumes
Data volumes zijn toegevoegd aan de ElasticSearch configuratie om ervoor te zorgen dat de gepersisteerde data beschikbaar blijft bij een reboot van de stack.

### ➕ Extra node toegevoegd
Om ervoor te zorgen dat onze data beschikbaar blijft wanneer de eerste ES node down gaat, is er een tweede node toegevoegd. Deze wordt automatisch gevonden door de hoofdnode wanneer deze voor het eerste opstart en de data die je toevoegt zal vervolgens gerepliceerd worden.

### ‼️ Production configuration
De documentatie van ES geeft aan dat de default configuratie **GEEN** productie configuratie is, dit dienen we dus te herbekijken wanneer de applicatie productie ready gemaakt dient te worden.